### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -109,7 +109,7 @@ AWS_EXPIRY = 60 * 60 * 24 * 7
 # Revert the following and use str after the above-mentioned bug is fixed in
 # either django-storage-redux or boto
 AWS_HEADERS = {
-    'Cache-Control': six.b('max-age=%d, s-maxage=%d, must-revalidate' % (
+    'Cache-Control': six.b('max-age={0:d}, s-maxage={1:d}, must-revalidate'.format(
         AWS_EXPIRY, AWS_EXPIRY))
 }
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jeffshek:betterself?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:jeffshek:betterself?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)